### PR TITLE
Fix broken pytest_qgis import

### DIFF
--- a/qmapshaper/utils.py
+++ b/qmapshaper/utils.py
@@ -2,9 +2,7 @@ import os
 from typing import Any
 from pathlib import Path
 
-from pytest_qgis import QgsVectorLayer
-
-from qgis.core import (QgsMessageLog, Qgis)
+from qgis.core import (QgsMessageLog, QgsVectorLayer, Qgis)
 
 from .text_constants import TextConstants
 


### PR DESCRIPTION
There was an import from `pytest_qgis` which made the plugin unusable in a stock QGIS installation as no such package exists by default. Imported was just QgsVectorLayer and no code actually using that import exist in `utils.py` except for some type hint. I  assume an import from `qgis.core` was actually meant to be used.

PS: Thanks so much for this plugin! Building something like it was on my bucket list for some months and what you made works so well. This is awesome!